### PR TITLE
feat(run-llm.sh): reduce the default ctx-size from 4096 to 512

### DIFF
--- a/api-server/llama-api-server/src/main.rs
+++ b/api-server/llama-api-server/src/main.rs
@@ -17,7 +17,7 @@ use wasi_nn::{Error as WasiNnError, Graph as WasiNnGraph, GraphExecutionContext,
 type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
 
 const DEFAULT_SOCKET_ADDRESS: &str = "0.0.0.0:8080";
-const DEFAULT_CTX_SIZE: &str = "4096";
+const DEFAULT_CTX_SIZE: &str = "512";
 
 static CTX_SIZE: OnceCell<usize> = OnceCell::new();
 
@@ -90,7 +90,7 @@ async fn main() -> Result<(), ServerError> {
                 .value_parser(clap::value_parser!(u32))
                 .value_name("BATCH_SIZE")
                 .help("Batch size for prompt processing")
-                .default_value("4096"),
+                .default_value("512"),
         )
         .arg(
             Arg::new("reverse_prompt")

--- a/chat/src/main.rs
+++ b/chat/src/main.rs
@@ -8,7 +8,7 @@ use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
-const DEFAULT_CTX_SIZE: &str = "4096";
+const DEFAULT_CTX_SIZE: &str = "512";
 static CTX_SIZE: OnceCell<usize> = OnceCell::new();
 
 #[allow(unreachable_code)]
@@ -57,7 +57,7 @@ fn main() -> Result<(), String> {
                 .value_parser(clap::value_parser!(u32))
                 .value_name("BATCH_SIZE")
                 .help("Batch size for prompt processing")
-                .default_value("4096"),
+                .default_value("512"),
         )
         .arg(
             Arg::new("reverse_prompt")

--- a/simple/src/main.rs
+++ b/simple/src/main.rs
@@ -2,7 +2,7 @@ use clap::{crate_version, Arg, ArgAction, Command};
 use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
 
-const DEFAULT_CTX_SIZE: &str = "4096";
+const DEFAULT_CTX_SIZE: &str = "512";
 static CTX_SIZE: OnceCell<usize> = OnceCell::new();
 
 fn main() -> Result<(), String> {
@@ -58,7 +58,7 @@ fn main() -> Result<(), String> {
                 .value_parser(clap::value_parser!(u32))
                 .value_name("BATCH_SIZE")
                 .help("Batch size for prompt processing")
-                .default_value("4096"),
+                .default_value("512"),
         )
         .arg(
             Arg::new("reverse_prompt")


### PR DESCRIPTION
The original default context size is 4096, which is not suitable for devices whose memory is less than 32GB. To give these users a better experience, reduce the default context size to a reasonable one, 512.