### PR TITLE
fix: fix the assignment issue of `metadata.ctx_size`

### DIFF
--- a/api-server/README.md
+++ b/api-server/README.md
@@ -223,7 +223,7 @@ The `-h` or `--help` option can list the available options of the `llama-api-ser
     -g, --n-gpu-layers <N_GPU_LAYERS>
             Number of layers to run on the GPU [default: 100]
     -b, --batch-size <BATCH_SIZE>
-            Batch size for prompt processing [default: 4096]
+            Batch size for prompt processing [default: 512]
     -r, --reverse-prompt <REVERSE_PROMPT>
             Halt generation at PROMPT, return control.
     -p, --prompt-template <TEMPLATE>

--- a/api-server/README.md
+++ b/api-server/README.md
@@ -217,7 +217,7 @@ The `-h` or `--help` option can list the available options of the `llama-api-ser
     -a, --model-alias <MODEL-ALIAS>
             Sets the alias name of the model in WasmEdge runtime [default: default]
     -c, --ctx-size <CTX_SIZE>
-            Sets the prompt context size [default: 4096]
+            Sets the prompt context size [default: 512]
     -n, --n-predict <N_PRDICT>
             Number of tokens to predict [default: 1024]
     -g, --n-gpu-layers <N_GPU_LAYERS>

--- a/api-server/llama-api-server/Cargo.toml
+++ b/api-server/llama-api-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-api-server"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [dependencies]

--- a/api-server/llama-api-server/src/main.rs
+++ b/api-server/llama-api-server/src/main.rs
@@ -90,7 +90,7 @@ async fn main() -> Result<(), ServerError> {
                 .value_parser(clap::value_parser!(u32))
                 .value_name("BATCH_SIZE")
                 .help("Batch size for prompt processing")
-                .default_value("4096"),
+                .default_value("512"),
         )
         .arg(
             Arg::new("reverse_prompt")

--- a/api-server/llama-api-server/src/main.rs
+++ b/api-server/llama-api-server/src/main.rs
@@ -17,7 +17,7 @@ use wasi_nn::{Error as WasiNnError, Graph as WasiNnGraph, GraphExecutionContext,
 type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
 
 const DEFAULT_SOCKET_ADDRESS: &str = "0.0.0.0:8080";
-const DEFAULT_CTX_SIZE: &str = "4096";
+const DEFAULT_CTX_SIZE: &str = "512";
 
 static CTX_SIZE: OnceCell<usize> = OnceCell::new();
 
@@ -194,6 +194,7 @@ async fn main() -> Result<(), ServerError> {
         return Err(ServerError::PromptContextSize);
     }
     println!("[INFO] Prompt context size: {size}", size = ctx_size);
+    options.ctx_size = *ctx_size as u64;
 
     // number of tokens to predict
     let n_predict = matches.get_one::<u32>("n_predict").unwrap();


### PR DESCRIPTION
In this PR, two changes are introduced:

1. fix the issue related to the assignment of `metadata.ctx_size`;
2. Update the default value of `ctx_size` CLI option from `4096` to `512`.